### PR TITLE
dont install release group in release workflow

### DIFF
--- a/moduleroot/.github/workflows/release.yml.erb
+++ b/moduleroot/.github/workflows/release.yml.erb
@@ -14,6 +14,8 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.0'
+        env:
+          BUNDLE_WITHOUT: release
       - name: Build gem
         run: gem build *.gemspec
       - name: Publish gem to rubygems.org


### PR DESCRIPTION
the release group from the Gemfile only pulls in the changelog generate
gem. that's only required if a person generates the changelog locally.
it's not required for the actual release/gem build.