### PR TITLE
Add simplecov integration

### DIFF
--- a/moduleroot/.github/workflows/test.yml.erb
+++ b/moduleroot/.github/workflows/test.yml.erb
@@ -13,12 +13,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby:
-          - "2.4"
-          - "2.5"
-          - "2.6"
-          - "2.7"
-          - "3.0"
+        include:
+          - ruby: "2.4"
+          - ruby: "2.5"
+          - ruby: "2.6"
+          - ruby: "2.7"
+          - ruby: "3.0"
+            coverage: "yes"
     steps:
       - uses: actions/checkout@v2
       - name: Install Ruby ${{ matrix.ruby }}
@@ -29,4 +30,6 @@ jobs:
         env:
           BUNDLE_WITHOUT: release
       - name: Run tests
+        env:
+          COVERAGE: ${{ matrix.coverage }}
         run: bundle exec rake spec

--- a/moduleroot/spec/spec_helper.rb.erb
+++ b/moduleroot/spec/spec_helper.rb.erb
@@ -1,3 +1,26 @@
+if ENV['COVERAGE'] == 'yes'
+  require 'simplecov'
+  require 'simplecov-console'
+  require 'codecov'
+
+  SimpleCov.start do
+    track_files 'lib/**/*.rb'
+
+    add_filter '/spec'
+
+    enable_coverage :branch
+
+    # do not track vendored files
+    add_filter '/vendor'
+    add_filter '/.vendor'
+  end
+
+  SimpleCov.formatters = [
+    SimpleCov::Formatter::Console,
+    SimpleCov::Formatter::Codecov,
+  ]
+end
+
 require 'puppet-lint'
 
 PuppetLint::Plugins.load_spec_helper


### PR DESCRIPTION
In addition to running modulesync...

In the plugin's gemspec file replace

```ruby
spec.add_development_dependency 'simplecov'
```

with

```ruby
spec.add_development_dependency 'codecov'
spec.add_development_dependency 'simplecov-console'
```

and add a badge to the README.