### PR TITLE
release action: only run on new tags

### DIFF
--- a/moduleroot/.github/workflows/release.yml.erb
+++ b/moduleroot/.github/workflows/release.yml.erb
@@ -1,8 +1,9 @@
 name: Release
 
 on:
-  create:
-    ref_type: tag
+  push:
+    tags:
+      - '*'
 
 jobs:
   release:


### PR DESCRIPTION
Previously the action was triggered on each push and/or merge. Now it
aligns with our codebase in https://github.com/voxpupuli/modulesync_config/blob/master/moduleroot/.github/workflows/release.yml.erb#L7-L10