### PR TITLE
Test against ruby versions used with Puppet 6 and 7

### DIFF
--- a/moduleroot/.github/workflows/test.yml.erb
+++ b/moduleroot/.github/workflows/test.yml.erb
@@ -14,11 +14,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - ruby: "2.4"
           - ruby: "2.5"
-          - ruby: "2.6"
           - ruby: "2.7"
-          - ruby: "3.0"
             coverage: "yes"
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
The docs below show that the latest Puppet 6 and 7 versions use ruby versions 2.5 and 2.7, respectively. 2.4 is too old and should be removed just as 2.6 does not correspond to a Puppet release.

See no reason to keep 3.0 except as a canary for future compatibility, in which case it should be allowed to fail.

https://puppet.com/docs/puppet/6/platform_lifecycle.html

https://puppet.com/docs/puppet/7/platform_lifecycle.html