### PR TITLE
Indent using regular spaces

### DIFF
--- a/moduleroot/Gemfile.erb
+++ b/moduleroot/Gemfile.erb
@@ -7,6 +7,6 @@ group :release do
 end
 
 group :coverage, optional: ENV['COVERAGE']!='yes' do
-￼ gem 'simplecov-console', :require => false
-￼ gem 'codecov', :require => false
+  gem 'simplecov-console', :require => false
+  gem 'codecov', :require => false
 end


### PR DESCRIPTION
These lines are indented with 2 chars in 4 bytes: `ef bf bc 20` instead
of the expected 2 chars in 2 bytes `20 20`.  This breaks bundler.

Replace the unexpected character with a regular space to unbreak
installing the bundle.