### PR TITLE
CI: ensure gem can be built

### DIFF
--- a/moduleroot/.github/workflows/test.yml.erb
+++ b/moduleroot/.github/workflows/test.yml.erb
@@ -31,3 +31,5 @@ jobs:
           bundler-cache: true
       - name: Run tests
         run: bundle exec rake spec
+      - name: Verify gem builds
+        run: gem build *.gemspec


### PR DESCRIPTION
This adds another step to our CI pipeline. We now ensure that the gem
can be build.