### PR TITLE
Gemfile: support Gemfile.local

### DIFF
--- a/moduleroot/Gemfile.erb
+++ b/moduleroot/Gemfile.erb
@@ -9,4 +9,8 @@ end
 group :coverage, optional: ENV['COVERAGE']!='yes' do
   gem 'simplecov-console', :require => false
   gem 'codecov', :require => false
+  end
+
+if File.exists? "#{__FILE__}.local"
+  eval(File.read("#{__FILE__}.local"), binding)
 end


### PR DESCRIPTION
To make our setup more flexibel and to support all gems on a long run,
we can update our Gemfile to eval() a Gemfile.local if it exists. That's
a common pattern already used in a few of our projects.