### PR TITLE
Skip installation of a bundle for releasing

### DIFF
--- a/moduleroot/.github/workflows/release.yml.erb
+++ b/moduleroot/.github/workflows/release.yml.erb
@@ -15,6 +15,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.0'
+          bundler: 'none'
       - name: Build gem
         run: gem build *.gemspec
       - name: Publish gem to rubygems.org


### PR DESCRIPTION
As noted in #25, only vanilla Ruby is used to release a gem, so we can
skip bundler completely.
