### PR TITLE
remove puppet-lint-classes_and_types_beginning_with_digits-check

### DIFF
--- a/managed_modules.yml
+++ b/managed_modules.yml
@@ -2,7 +2,6 @@
 - puppet-lint-absolute_classname-check
 - puppet-lint-anchor-check
 - puppet-lint-appends-check
-- puppet-lint-classes_and_types_beginning_with_digits-check
 - puppet-lint-empty_string-check
 - puppet-lint-file_ensure-check
 - puppet-lint-leading_zero-check


### PR DESCRIPTION
let's remove the plugin here and archive the repository, it's obsolete
see also
https://github.com/voxpupuli/puppet-lint-classes_and_types_beginning_with_digits-check/pull/12