### PR TITLE
CI: Run on PRs and merges to master

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,10 @@
 name: noop run
 
 on:
-  - pull_request
-  - push
+  pull_request: {}
+  push:
+    branches:
+      - master
 
 jobs:
   unit:

--- a/moduleroot/.github/workflows/test.yml.erb
+++ b/moduleroot/.github/workflows/test.yml.erb
@@ -1,8 +1,11 @@
 name: Test
 
 on:
-  - pull_request
-  - push
+  pull_request: {}
+  push:
+    branches:
+      - master
+      - main
 
 env:
   BUNDLE_WITHOUT: release


### PR DESCRIPTION
@ekohl this is per our conversation on IRC.  runs on master will update the cache and that should be reused for PR runs to make them faster.