### PR TITLE
lint plugins: Drop Ruby < 2.7 support

### DIFF
--- a/moduleroot/.github/workflows/test.yml.erb
+++ b/moduleroot/.github/workflows/test.yml.erb
@@ -17,9 +17,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - ruby: "2.4"
-          - ruby: "2.5"
-          - ruby: "2.6"
           - ruby: "2.7"
           - ruby: "3.0"
           - ruby: "3.1"


### PR DESCRIPTION
This is required to support latest puppet-lint and Puppet 8.