### PR TITLE
list development deps in Gemfile

### DIFF
--- a/moduleroot/Gemfile.erb
+++ b/moduleroot/Gemfile.erb
@@ -10,4 +10,10 @@ end
 group :coverage, optional: ENV['COVERAGE']!='yes' do
   gem 'simplecov-console', :require => false
   gem 'codecov', :require => false
+
+group :development do
+  gem 'rake', '~> 13.0', '>= 13.0.6'
+  gem 'rspec', '~> 3.12'
+  gem 'rspec-collection_matchers', '~> 1.2'
+  gem 'rspec-its', '~> 1.3'
 end


### PR DESCRIPTION
This allows us to manage them in a central place. Before, they were all listed in the individual gemspec files. The Gemfile is managed by modulesync, the gemspec not.