### PR TITLE
bump voxpupuli rubocop dependency to 2.0

### DIFF
--- a/moduleroot/Gemfile.erb
+++ b/moduleroot/Gemfile.erb
@@ -17,5 +17,5 @@ group :development do
   gem 'rspec', '~> 3.12'
   gem 'rspec-collection_matchers', '~> 1.2'
   gem 'rspec-its', '~> 1.3'
-  gem 'voxpupuli-rubocop', '~> 1.1'
+  gem 'voxpupuli-rubocop', '~> 2.0'
 end


### PR DESCRIPTION
Brings modulesync up to date with the rubocop dependency already patched into the managed modules via dependabot PRs