### PR TITLE
Require rspec-collection_matchers

### DIFF
--- a/moduleroot/spec/spec_helper.rb.erb
+++ b/moduleroot/spec/spec_helper.rb.erb
@@ -25,5 +25,6 @@ else
 end
 
 require 'puppet-lint'
+require 'rspec/collection_matchers'
 
 PuppetLint::Plugins.load_spec_helper


### PR DESCRIPTION
We need to require `rspec/collection_matchers` as puppet-lint 4.2.1 and later no longer requires this in their spec_helper. Without this the tests in several plugins fails.

I opened an issue about problems running tests as voxpupuli/puppet-lint-strict_indent-check#41 before knowing about modulesync.