### PR TITLE
Remove SimpleCov code as it gets done by PuppetLint

### DIFF
--- a/moduleroot/spec/spec_helper.rb.erb
+++ b/moduleroot/spec/spec_helper.rb.erb
@@ -1,29 +1,5 @@
 # frozen_string_literal: true
 
-begin
-  require 'simplecov'
-  require 'simplecov-console'
-  require 'codecov'
-rescue LoadError
-else
-  SimpleCov.start do
-    track_files 'lib/**/*.rb'
-
-    add_filter '/spec'
-
-    enable_coverage :branch
-
-    # do not track vendored files
-    add_filter '/vendor'
-    add_filter '/.vendor'
-  end
-
-  SimpleCov.formatters = [
-    SimpleCov::Formatter::Console,
-    SimpleCov::Formatter::Codecov,
-  ]
-end
-
 require 'puppet-lint'
 require 'rspec/collection_matchers'
 


### PR DESCRIPTION
Pull the fix for [this issue](https://github.com/voxpupuli/puppet-lint-strict_indent-check/issues/45) back into the modulesync template.

The code is not compatible with this change in puppet-lint which re-enabled code coverage there:
https://github.com/puppetlabs/puppet-lint/commit/89ae51d68f9a1571ad030409a9bfde0eb504f779

The call to `PuppetLint::Plugins.load_spec_helper` sets up the coverage configuration and calls `SimpleCov.start` this conflicts with the code here as it can only be started once.