### PR TITLE
Add puppet-lint-params_not_optional_with_undef-check plugin

### DIFF
--- a/managed_modules.yml
+++ b/managed_modules.yml
@@ -12,6 +12,7 @@
 - puppet-lint-param-docs
 - puppet-lint-param-types
 - puppet-lint-params_empty_string-check
+- puppet-lint-params_not_optional_with_undef-check
 - puppet-lint-reference_on_declaration_outside_of_class-check
 - puppet-lint-resource_reference_syntax
 - puppet-lint-spaceship_operator_without_tag-check


### PR DESCRIPTION
We own this plugin since the ages, but forgot to add it to modulesync.