### PR TITLE
Update puppet-lint test matrix for current Ruby

### DIFF
--- a/moduleroot/.github/workflows/test.yml.erb
+++ b/moduleroot/.github/workflows/test.yml.erb
@@ -21,12 +21,12 @@ jobs:
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.3'
+          ruby-version: '3.4'
           bundler-cache: true
       - name: Run rake rubocop
         run: bundle exec rake rubocop
       - id: ruby
-        uses: voxpupuli/ruby-version@v1
+        uses: voxpupuli/ruby-version@v2
 
   test:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Summary
- update the template RuboCop job from Ruby 3.3 to Ruby 3.4
- use `voxpupuli/ruby-version@v2` for generated test matrices so synced puppet-lint plugins can include the current supported Ruby list

## Context
This is a focused first step for voxpupuli/community-triage#35. The template already delegates the spec matrix to `voxpupuli/ruby-version`; this PR moves it to the newer action generation and keeps the fixed RuboCop job on the current stable Ruby.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file("moduleroot/.github/workflows/test.yml.erb"); puts "yaml ok"'`
- `git diff --check`
